### PR TITLE
fix: use production domain in meta tags for search results

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,19 +13,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <title>Toronto Tech Meetups & Events | GTA Tech Community</title>
+    <link rel="canonical" href="https://www.gta-dev-web.com/" />
 
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="GTA Tech Meetups" />
+    <meta property="og:title" content="Toronto Tech Meetups & Events | GTA Tech Community" />
     <meta property="og:description" content="A curated list of tech-related meetups and communities in the Greater Toronto Area (GTA)." />
-    <meta property="og:image" content="https://gta-dev-web.vercel.app/ogp.png" />
-    <meta property="og:url" content="https://gta-dev-web.vercel.app/" />
+    <meta property="og:image" content="https://www.gta-dev-web.com/ogp.png" />
+    <meta property="og:url" content="https://www.gta-dev-web.com/" />
     <meta property="og:type" content="website" />
 
     <!-- Twitter Card for better social sharing -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="GTA Tech Meetups" />
+    <meta name="twitter:title" content="Toronto Tech Meetups & Events | GTA Tech Community" />
     <meta name="twitter:description" content="A curated list of tech-related meetups and communities in the Greater Toronto Area (GTA)." />
-    <meta name="twitter:image" content="https://gta-dev-web.vercel.app/ogp.png" />
+    <meta name="twitter:image" content="https://www.gta-dev-web.com/ogp.png" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- Add `<link rel="canonical">` pointing to `https://www.gta-dev-web.com/`
- Update `og:url` and `og:image` from `gta-dev-web.vercel.app` to `www.gta-dev-web.com`
- Align `og:title` and `twitter:title` with the `<title>` tag for consistency

Search results were showing the raw URL instead of the page title due to the Vercel preview domain mismatch in meta tags.

## Test plan

- [ ] Verify meta tags in page source after deploy
- [ ] Re-request indexing via Google Search Console to pick up the canonical URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)