### PR TITLE
feat: add AI Tinkerers Toronto as a meetup source

### DIFF
--- a/scripts/scrape-meetups.ts
+++ b/scripts/scrape-meetups.ts
@@ -74,6 +74,24 @@ async function scrapeMeetupPage(url: string) {
       const description = $('meta[property="og:description"]').attr('content')?.trim() || $('p').first().text().trim();
       const name = 'Toronto Ruby';
       return { name, description, logo: fullLogoUrl };
+    } else if (url.includes('aitinkerers.org')) {
+      const name = $('title').text().replace(/\s*\|.*$/, '').trim() || 'AI Tinkerers - Toronto';
+      const logoUrl = $('img[alt*="AI Tinkerers"]').first().attr('src') || $('img[alt*="AI Events"]').first().attr('src');
+      const fullLogoUrl = logoUrl ? new URL(logoUrl, url).href : null;
+      // Extract description from JSON-LD schema
+      const jsonLd = $('script[type="application/ld+json"]').html();
+      let description = '';
+      if (jsonLd) {
+        try {
+          const schema = JSON.parse(jsonLd);
+          const firstEvent = schema?.itemListElement?.[0]?.item;
+          description = firstEvent?.organizer?.description || firstEvent?.description || '';
+        } catch { /* ignore */ }
+      }
+      if (!description) {
+        description = $('meta[name="description"]').attr('content')?.trim() || $('meta[property="og:description"]').attr('content')?.trim() || '';
+      }
+      return { name, description, logo: fullLogoUrl };
     } else if (url.includes('builder-sundays') || url.includes('buildersundays')) {
       const name = $('img[alt="Builder Sundays"]').attr('alt') || 'Builder Sundays';
       const description = $('div[class*="rich_text"] p').map((_, el) => $(el).text().trim()).get().join('\n\n');

--- a/src/data/meetups.ts
+++ b/src/data/meetups.ts
@@ -132,12 +132,11 @@ export const meetupSources: MeetupSource[] = [
   //   platform: "other",
   //   type: "meetups",
   // },
-  // TODO: Need custom scraping script for AI Tinkerers
-  // {
-  //   url: "https://aitinkerers.org/p/welcome",
-  //   platform: "other",
-  //   type: "meetups",
-  // },
+  {
+    url: "https://toronto.aitinkerers.org/",
+    platform: "other",
+    type: "meetups",
+  },
   {
     url: "https://www.meetup.com/toronto-ai-aligners/",
     platform: "meetup",


### PR DESCRIPTION
## Summary

- Add [AI Tinkerers Toronto](https://toronto.aitinkerers.org/) as a new meetup source
- Scrape group info (name, logo, description) via JSON-LD schema and HTML meta tags
- Scrape events (title, datetime, venue, description, link, image) from JSON-LD `ItemList` — no Puppeteer needed
- Replace the existing TODO comment in `src/data/meetups.ts`

## Test plan

- [x] `DRY_RUN=true npm run scrape:meetups` — AI Tinkerers group info extracted (name, logo, description)
- [x] Standalone test — 10 events scraped from JSON-LD including upcoming Feb 2026 event
- [ ] Run full scraper after merge to insert into Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)