### PR TITLE
chore: remove meetup scraper from scheduled GitHub Action

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -18,5 +18,4 @@ jobs:
         with:
           node-version: '20'
       - run: npm install
-      - run: npm run scrape:meetups
       - run: npm run scrape:events


### PR DESCRIPTION
## Summary

- Remove `npm run scrape:meetups` from the daily GitHub Actions workflow
- Group info (name, description, logo) rarely changes, so it can be run manually when needed
- `npm run scrape:events` continues to run daily at 5 AM ET

🤖 Generated with [Claude Code](https://claude.com/claude-code)