### PR TITLE
perf: improve Cumulative Layout Shift (CLS) score

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,15 @@
     <meta name="twitter:image" content="https://www.gta-dev-web.com/ogp.png" />
   </head>
   <body>
+    <script>
+      // Apply theme before first paint to prevent CLS from theme flash
+      (function() {
+        var theme = localStorage.getItem('theme') || 'system';
+        var isDark = theme === 'dark' ||
+          (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) document.documentElement.classList.add('dark');
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Users, Github, CalendarDays, Menu } from 'lucide-react';
 import { MeetupGrid } from './components/MeetupGrid';
+import { MeetupGridSkeleton } from './components/Skeleton';
 import { Events } from './pages/Events';
 import { ThemeToggle } from './components/ThemeToggle';
 import type { MeetupGroup } from './types/meetup';
@@ -171,8 +172,8 @@ function App() {
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <h2 className="sr-only">Toronto Tech Meetups and Communities</h2>
           {loading ? (
-            <div className="flex items-center justify-center h-64" role="status">
-              <div className="text-gray-600 dark:text-gray-300">Loading meetups...</div>
+            <div role="status" aria-label="Loading meetups">
+              <MeetupGridSkeleton />
             </div>
           ) : error ? (
             <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300" role="alert">

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -35,6 +35,10 @@ export function EventList({ events }: EventListProps) {
                   src={event.logo}
                   alt={`${event.title} logo`}
                   className="w-full h-full object-cover"
+                  width={320}
+                  height={320}
+                  loading="lazy"
+                  decoding="async"
                 />
               ) : (
                 <Calendar className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-gray-400 dark:text-gray-500" />

--- a/src/components/MeetupCard.tsx
+++ b/src/components/MeetupCard.tsx
@@ -20,6 +20,10 @@ export function MeetupCard({ meetup }: MeetupCardProps) {
             src={meetup.logo}
             alt={`${meetup.name} logo`}
             className="w-full h-full object-cover"
+            width={640}
+            height={360}
+            loading="lazy"
+            decoding="async"
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center">

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+function SkeletonBlock({ className }: { className?: string }) {
+  return (
+    <div
+      className={`animate-pulse bg-gray-200 dark:bg-gray-700 rounded ${className ?? ''}`}
+    />
+  );
+}
+
+export function MeetupCardSkeleton() {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden">
+      <SkeletonBlock className="aspect-[16/9] w-full !rounded-none" />
+      <div className="p-6">
+        <SkeletonBlock className="h-6 w-3/4 mb-2" />
+        <SkeletonBlock className="h-4 w-full" />
+        <SkeletonBlock className="h-4 w-2/3 mt-1" />
+      </div>
+    </div>
+  );
+}
+
+export function MeetupGridSkeleton() {
+  return (
+    <div className="space-y-12">
+      <div className="space-y-8">
+        <SkeletonBlock className="h-8 w-32" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <MeetupCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function EventItemSkeleton() {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden">
+      <div className="flex flex-col md:flex-row">
+        <SkeletonBlock className="w-full md:w-1/4 aspect-video md:aspect-square !rounded-none" />
+        <div className="flex-1 p-6">
+          <SkeletonBlock className="h-6 w-3/4 mb-4" />
+          <SkeletonBlock className="h-4 w-1/2 mb-2" />
+          <SkeletonBlock className="h-4 w-1/3 mb-4" />
+          <SkeletonBlock className="h-4 w-full" />
+          <SkeletonBlock className="h-4 w-2/3 mt-1" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function EventListSkeleton() {
+  return (
+    <div className="space-y-6">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <EventItemSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { EventList } from '../components/EventList';
+import { EventListSkeleton } from '../components/Skeleton';
 import { supabase } from '../lib/supabase';
 import { getCached, isFresh, setCache } from '../lib/cache';
 import type { Event } from '../types/event';
@@ -66,10 +67,9 @@ export function Events() {
 
   if (loading) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="flex items-center justify-center h-64" role="status">
-          <div className="text-gray-600 dark:text-gray-300">Loading events...</div>
-        </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12" role="status" aria-label="Loading events">
+        <div className="h-8 w-80 animate-pulse bg-gray-200 dark:bg-gray-700 rounded mb-8" />
+        <EventListSkeleton />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Replace fixed-height loading placeholders with **skeleton screens** that match the actual content layout, eliminating the large layout shift when data loads
- Add explicit `width`/`height`, `loading="lazy"`, and `decoding="async"` to `<img>` tags in `MeetupCard` and `EventList` so browsers can reserve space before images load
- Add an **inline theme script** in `index.html` to apply the `dark` class before first paint, preventing a flash of light mode for dark-mode users

## Test plan
- [ ] Verify skeleton screens appear during loading and match the layout of actual content (meetups grid + events list)
- [ ] Verify no visible layout shift when data loads (use Chrome DevTools Performance > CLS overlay)
- [ ] Verify dark mode users see no flash of light mode on page load
- [ ] Verify images still render correctly with the new attributes
- [ ] Run Lighthouse and confirm CLS score improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)